### PR TITLE
Fix for typedef in different namespace

### DIFF
--- a/src/CppAst.Tests/TestNamespaces.cs
+++ b/src/CppAst.Tests/TestNamespaces.cs
@@ -52,5 +52,30 @@ namespace A::B::C
                 }
             );
         }
+
+        [Test]
+        public void TestNamespacedTypedef() {
+            ParseAssert(@"
+namespace A
+{
+    typedef int (*a)(int b);
+}
+A::a c;
+",
+                compilation => {
+                    Assert.False(compilation.HasErrors);
+
+                    Assert.AreEqual(1, compilation.Namespaces.Count);
+                    ICppGlobalDeclarationContainer container = compilation.Namespaces[0];
+                    Assert.AreEqual(1, container.Typedefs.Count);
+                    Assert.AreEqual(1, compilation.Fields.Count);
+
+                    CppTypedef typedef = container.Typedefs[0];
+                    CppField field = compilation.Fields[0];
+
+                    Assert.AreEqual(typedef, field.Type);
+                }
+            );
+        }
     }
 }

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -1561,6 +1561,16 @@ namespace CppAst
             return type;
         }
 
+        private CppType VisitElaboratedDecl(CXCursor cursor, CXType type, CXCursor parent, void* data)
+        {
+            var fulltypeDefName = clang.getCursorUSR(cursor).CString;
+            if (_typedefs.TryGetValue(fulltypeDefName, out var typeRef)) {
+                return typeRef;
+            }
+
+            return GetCppType(type.CanonicalType.Declaration, type.CanonicalType, parent, data);
+        }
+
         private static string GetCursorAsText(CXCursor cursor) => new Tokenizer(cursor).TokensToString();
 
         private string GetCursorAsTextBetweenOffset(CXCursor cursor, int startOffset, int endOffset)
@@ -1688,9 +1698,7 @@ namespace CppAst
                     return VisitTypeDefDecl(cursor, data);
 
                 case CXTypeKind.CXType_Elaborated:
-                    {
-                        return GetCppType(type.CanonicalType.Declaration, type.CanonicalType, parent, data);
-                    }
+                    return VisitElaboratedDecl(cursor, type, parent, data);
 
                 case CXTypeKind.CXType_ConstantArray:
                 case CXTypeKind.CXType_IncompleteArray:


### PR DESCRIPTION
Hi there,

This PR fixes https://github.com/xoofx/CppAst.NET/issues/48

i found the reason for the failed typedef resolution:

When a reference to a typedef in a different namespace gets parsed, it won’t be of thy type `CXType_Typedef` but `CXType_Elaborated`.

The solution was to try to find an already defined typedefs when encountering a `CXType_Elaborated` before creating a new Type.

I also created a test-case for this bug.
