### PR TITLE
Add support for variadic function arguments.

### DIFF
--- a/src/CppAst.Tests/TestFunctions.cs
+++ b/src/CppAst.Tests/TestFunctions.cs
@@ -215,6 +215,46 @@ int function1();
             );
         }
 
+        [Test]
+        public void TestFunctionVariadic()
+        {
+            ParseAssert(@"
+void function0();
+void function1(...);
+void function2(int, ...);
+",
+                compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+
+                    Assert.AreEqual(3, compilation.Functions.Count);
+
+                    {
+                        var cppFunction = compilation.Functions[0];
+                        Assert.AreEqual(0, cppFunction.Parameters.Count);
+                        Assert.AreEqual("void", cppFunction.ReturnType.ToString());
+                        Assert.AreEqual(CppFunctionFlags.None, cppFunction.Flags & CppFunctionFlags.Variadic);
+                    }
+
+                    {
+                        var cppFunction = compilation.Functions[1];
+                        Assert.AreEqual(0, cppFunction.Parameters.Count);
+                        Assert.AreEqual("void", cppFunction.ReturnType.ToString());
+                        Assert.AreEqual(CppFunctionFlags.Variadic, cppFunction.Flags & CppFunctionFlags.Variadic);
+                    }
+
+                    {
+                        var cppFunction = compilation.Functions[2];
+                        Assert.AreEqual(1, cppFunction.Parameters.Count);
+                        Assert.AreEqual(string.Empty, cppFunction.Parameters[0].Name);
+                        Assert.AreEqual(CppTypeKind.Primitive, cppFunction.Parameters[0].Type.TypeKind);
+                        Assert.AreEqual(CppPrimitiveKind.Int, ((CppPrimitiveType)cppFunction.Parameters[0].Type).Kind);
+                        Assert.AreEqual("void", cppFunction.ReturnType.ToString());
+                        Assert.AreEqual(CppFunctionFlags.Variadic, cppFunction.Flags & CppFunctionFlags.Variadic);
+                    }
+                }
+            );
+        }
 
     }
 }

--- a/src/CppAst/CppFunction.cs
+++ b/src/CppAst/CppFunction.cs
@@ -117,6 +117,11 @@ namespace CppAst
                 builder.Append(param);
             }
 
+            if ((Flags & CppFunctionFlags.Variadic) != 0)
+            {
+                builder.Append(", ...");
+            }
+
             builder.Append(")");
 
             if ((Flags & CppFunctionFlags.Const) != 0)

--- a/src/CppAst/CppFunctionFlags.cs
+++ b/src/CppAst/CppFunctionFlags.cs
@@ -56,5 +56,10 @@ namespace CppAst
         /// This is a C++ destructor
         /// </summary>
         Destructor = 1 << 7,
+
+        /// <summary>
+        /// This is a variadic function (has `...` parameter)
+        /// </summary>
+        Variadic = 1 << 8,
     }
 }

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -1108,6 +1108,11 @@ namespace CppAst
                 cppFunction.Flags |= CppFunctionFlags.Inline;
             }
 
+            if (cursor.IsVariadic)
+            {
+                cppFunction.Flags |= CppFunctionFlags.Variadic;
+            }
+
             if (cursor.CXXMethod_IsConst)
             {
                 cppFunction.Flags |= CppFunctionFlags.Const;


### PR DESCRIPTION
This should fix #40. Just adding a simple function flag indicating that a function has variadic arguments and code/tests to support it.

I considered also adding support to function types (same basic code), but I was unsure about how it should be implemented. I could have either added a boolean property `IsVariadic` or I could have added a `Flags` property similar to the way it is done on `CppFunction`.