### PR TITLE
Add Offset to CppField

### DIFF
--- a/src/CppAst.Tests/TestStructs.cs
+++ b/src/CppAst.Tests/TestStructs.cs
@@ -74,6 +74,7 @@ public:
                         Assert.AreEqual(CppTypeKind.Primitive, cppStruct.Fields[1].Type.TypeKind);
                         Assert.AreEqual(CppPrimitiveKind.Float, ((CppPrimitiveType) cppStruct.Fields[1].Type).Kind);
                         Assert.AreEqual(CppVisibility.Public, cppStruct.Fields[1].Visibility);
+                        Assert.AreEqual(sizeof(int), cppStruct.Fields[1].Offset);
                         Assert.AreEqual(sizeof(int) + sizeof(float), cppStruct.SizeOf);
                     }
                 }
@@ -101,6 +102,8 @@ struct
                         var cppStruct = compilation.Classes[0];
                         Assert.AreEqual(string.Empty, cppStruct.Name);
                         Assert.AreEqual(2, cppStruct.Fields.Count);
+                        Assert.AreEqual(sizeof(int), cppStruct.Fields[1].Offset);
+                        Assert.AreEqual(sizeof(int) + sizeof(int), cppStruct.SizeOf);
                     }
                 }
             );

--- a/src/CppAst/CppField.cs
+++ b/src/CppAst/CppField.cs
@@ -64,7 +64,12 @@ namespace CppAst
         /// Gets or sets the number of bits for this bit field. Only valid if <see cref="IsBitField"/> is <c>true</c>.
         /// </summary>
         public int BitFieldWidth { get; set; }
-
+        
+        /// <summary>
+        /// Gets or sets the offset of the field in bytes.
+        /// </summary>
+        public long Offset { get; set; }
+        
         /// <inheritdoc />
         public override string ToString()
         {

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -713,6 +713,7 @@ namespace CppAst
                 StorageQualifier = GetStorageQualifier(cursor),
                 IsBitField = cursor.IsBitField,
                 BitFieldWidth = cursor.FieldDeclBitWidth,
+                Offset = cursor.OffsetOfField / 8,
             };
             containerContext.DeclarationContainer.Fields.Add(cppField);
             cppField.Attributes = ParseAttributes(cursor);
@@ -735,6 +736,7 @@ namespace CppAst
                 Visibility = containerContext.CurrentVisibility,
                 StorageQualifier = GetStorageQualifier(cursor),
                 IsAnonymous = true,
+                Offset = cursor.OffsetOfField / 8,
             };
             containerContext.DeclarationContainer.Fields.Add(cppField);
             cppField.Attributes = ParseAttributes(cursor);


### PR DESCRIPTION
It would be nice to have offset exposed. Specifically, I'd like to use it for ExplicitLayout when generating C# bindings.