### PR TITLE
Enhance for function template & CppType FullName support.

### DIFF
--- a/src/CppAst.Tests/TestFunctions.cs
+++ b/src/CppAst.Tests/TestFunctions.cs
@@ -256,5 +256,32 @@ void function2(int, ...);
             );
         }
 
+
+
+        [Test]
+        public void TestFunctionTemplate()
+        {
+            ParseAssert(@"
+template<class T>
+void function0(T t);
+",
+                compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+
+                    Assert.AreEqual(1, compilation.Functions.Count);
+
+                    {
+                        var cppFunction = compilation.Functions[0];
+                        Assert.AreEqual(1, cppFunction.Parameters.Count);
+                        Assert.AreEqual("void", cppFunction.ReturnType.ToString());
+                        Assert.AreEqual(cppFunction.IsFunctionTemplate, true);
+                        Assert.AreEqual(cppFunction.TemplateParameters.Count, 1);
+                    }
+
+                }
+            );
+        }
+
     }
 }

--- a/src/CppAst/CppBaseType.cs
+++ b/src/CppAst/CppBaseType.cs
@@ -51,6 +51,31 @@ namespace CppAst
             }
 
             builder.Append(Type.GetDisplayName());
+
+            var cls = Type as CppClass;
+            if(cls != null && cls.TemplateKind != CppTemplateKind.NormalClass)
+            {
+                builder.Append("<");
+
+                if (cls.TemplateKind == CppTemplateKind.TemplateSpecializedClass)
+                {
+                    for (var i = 0; i < cls.TemplateSpecializedArguments.Count; i++)
+                    {
+                        if (i > 0) builder.Append(", ");
+                        builder.Append(cls.TemplateSpecializedArguments[i].ToString());
+                    }
+                }
+                else if (cls.TemplateKind == CppTemplateKind.TemplateClass)
+                {
+                    for (var i = 0; i < cls.TemplateParameters.Count; i++)
+                    {
+                        if (i > 0) builder.Append(", ");
+                        builder.Append(cls.TemplateParameters[i].ToString());
+                    }
+                }
+
+                builder.Append(">");
+            }
             return builder.ToString();
         }
     }

--- a/src/CppAst/CppClass.cs
+++ b/src/CppAst/CppClass.cs
@@ -41,20 +41,57 @@ namespace CppAst
         /// <inheritdoc />
         public string Name { get; set; }
 
-        public string FullName 
-        { 
-            get 
+        public override string FullName
+        {
+            get
             {
+                StringBuilder sb = new StringBuilder();
                 string fullparent = FullParentName;
-                if(string.IsNullOrEmpty(fullparent))
+                if (string.IsNullOrEmpty(fullparent))
                 {
-                    return Name;
+                    sb.Append(Name);
                 }
                 else
                 {
-                    return $"{fullparent}{Name}";
+                    sb.Append($"{fullparent}::{Name}");
                 }
-            } 
+
+                if (TemplateKind == CppTemplateKind.TemplateClass
+                    || TemplateKind == CppTemplateKind.PartialTemplateClass)
+                {
+                    sb.Append('<');
+                    for (int i = 0; i < TemplateParameters.Count; i++)
+                    {
+                        var tp = TemplateParameters[i];
+                        if (i != 0)
+                        {
+                            sb.Append(", ");
+                        }
+                        sb.Append(tp.ToString());
+                    }
+                    sb.Append('>');
+                }
+                else if (TemplateKind == CppTemplateKind.TemplateSpecializedClass)
+                {
+                    sb.Append('<');
+                    for (int i = 0; i < TemplateSpecializedArguments.Count; i++)
+                    {
+                        var ta = TemplateSpecializedArguments[i];
+                        if (i != 0)
+                        {
+                            sb.Append(", ");
+                        }
+                        sb.Append(ta.ArgString);
+                    }
+                    sb.Append('>');
+                }
+                //else if(TemplateKind == CppTemplateKind.PartialTemplateClass)
+                //{
+                //    sb.Append('<');
+                //    sb.Append('>');
+                //}
+                return sb.ToString();
+            }
         }
 
         /// <inheritdoc />

--- a/src/CppAst/CppElement.cs
+++ b/src/CppAst/CppElement.cs
@@ -25,35 +25,46 @@ namespace CppAst
         {
             get
             {
-				string tmpname = "";
-				var p = Parent;
-				while (p != null)
-				{
-					if (p is CppClass)
-					{
-						var cpp = p as CppClass;
-						tmpname = $"{cpp.Name}::{tmpname}";
-						p = cpp.Parent;
-					}
-					else if (p is CppNamespace)
-					{
-						var ns = p as CppNamespace;
-						tmpname = $"{ns.Name}::{tmpname}";
-						p = ns.Parent;
-					}
-					else if (p is CppCompilation)
-					{
-						// root namespace here, just ignore~
-						p = null;
-					}
-					else
-					{
-						throw new NotImplementedException("Can not be here, not support type here!");
-					}
-				}
+                string tmpname = "";
+                var p = Parent;
+                while (p != null)
+                {
+                    if (p is CppClass)
+                    {
+                        var cpp = p as CppClass;
+                        tmpname = $"{cpp.Name}::{tmpname}";
+                        p = cpp.Parent;
+                    }
+                    else if (p is CppNamespace)
+                    {
+                        var ns = p as CppNamespace;
 
-				return tmpname;
-			}
+                        //Just ignore inline namespace
+                        if (!ns.IsInlineNamespace)
+                        {
+                            tmpname = $"{ns.Name}::{tmpname}";
+                        }
+                        p = ns.Parent;
+                    }
+                    else if (p is CppCompilation)
+                    {
+                        // root namespace here, just ignore~
+                        p = null;
+                    }
+                    else
+                    {
+                        throw new NotImplementedException("Can not be here, not support type here!");
+                    }
+                }
+
+                //Try to remove not need `::` in string tails.
+                if (tmpname.EndsWith("::"))
+                {
+                    tmpname = tmpname.Substring(0, tmpname.Length - 2);
+                }
+
+                return tmpname;
+            }
         }
 
         /// <summary>

--- a/src/CppAst/CppEnum.cs
+++ b/src/CppAst/CppEnum.cs
@@ -30,22 +30,21 @@ namespace CppAst
         /// <inheritdoc />
         public string Name { get; set; }
 
-		public string FullName
-		{
-			get
-			{
-				string fullparent = FullParentName;
-				if (string.IsNullOrEmpty(fullparent))
-				{
-					return Name;
-				}
-				else
-				{
-					return $"{fullparent}{Name}";
-				}
-			}
-		}
-
+        public override string FullName
+        {
+            get
+            {
+                string fullparent = FullParentName;
+                if (string.IsNullOrEmpty(fullparent))
+                {
+                    return Name;
+                }
+                else
+                {
+                    return $"{fullparent}::{Name}";
+                }
+            }
+        }
 
 		/// <summary>
 		/// Gets or sets a boolean indicating if this enum is scoped.

--- a/src/CppAst/CppFunction.cs
+++ b/src/CppAst/CppFunction.cs
@@ -97,6 +97,7 @@ namespace CppAst
 
         public bool IsConst => ((int)Flags & (int)CppFunctionFlags.Const) != 0;
 
+        public bool IsFunctionTemplate => ((int)Flags & (int)CppFunctionFlags.FunctionTemplate) != 0;
 
         /// <inheritdoc />
         public List<CppType> TemplateParameters { get; }

--- a/src/CppAst/CppFunctionFlags.cs
+++ b/src/CppAst/CppFunctionFlags.cs
@@ -61,5 +61,10 @@ namespace CppAst
         /// This is a variadic function (has `...` parameter)
         /// </summary>
         Variadic = 1 << 8,
+
+        /// <summary>
+        /// This is a function template (has template params in function)
+        /// </summary>
+        FunctionTemplate = 1 << 9,
     }
 }

--- a/src/CppAst/CppGlobalDeclarationContainer.cs
+++ b/src/CppAst/CppGlobalDeclarationContainer.cs
@@ -109,6 +109,21 @@ namespace CppAst
                 if (t != null) return t;
             }
 
+            //Not found, try to find in inline namespace.
+            if(parent is CppNamespace)
+            {
+                var ns = parent as CppNamespace;
+                foreach(var sn in ns.Namespaces)
+                {
+                    if (sn.IsInlineNamespace)
+                    {
+                        var findElem = SearchForChild(sn, child_name);
+                        //Find it in inline namespace, just return.
+                        if(findElem != null) return findElem;
+                    }
+                }
+            }
+
             return null;
         }
 
@@ -117,7 +132,7 @@ namespace CppAst
         /// </summary>
         /// <param name="name">Name of the element to find</param>
         /// <returns>The CppElement found or null if not found</returns>
-        public CppElement FindByFullName(string name)
+		public CppElement FindByFullName(string name)
         {
             var arr = name.Split(new string[] { "::" }, StringSplitOptions.RemoveEmptyEntries);
             if(arr.Length == 0) return null;

--- a/src/CppAst/CppNamespace.cs
+++ b/src/CppAst/CppNamespace.cs
@@ -33,6 +33,11 @@ namespace CppAst
         /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// Is the namespace inline or not(such as std::__1::vector).
+        /// </summary>
+        public bool IsInlineNamespace { get; set; }
+
         /// <inheritdoc />
         public CppContainerList<CppField> Fields { get; }
 

--- a/src/CppAst/CppTemplateArgument.cs
+++ b/src/CppAst/CppTemplateArgument.cs
@@ -10,30 +10,30 @@ namespace CppAst
     /// <summary>
     /// For c++ specialized template argument
     /// </summary>
-    public class CppTemplateArgument : CppElement
+    public class CppTemplateArgument : CppType
     {
-		public CppTemplateArgument(CppType sourceParam, CppType typeArg)
+        public CppTemplateArgument(CppType sourceParam, CppType typeArg) : base(CppTypeKind.TemplateArgumentType)
         {
             SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
             ArgAsType = typeArg ?? throw new ArgumentNullException(nameof(typeArg));
             ArgKind = CppTemplateArgumentKind.AsType;
         }
 
-		public CppTemplateArgument(CppType sourceParam, long intArg)
-		{
+        public CppTemplateArgument(CppType sourceParam, long intArg) : base(CppTypeKind.TemplateArgumentType)
+        {
 			SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
             ArgAsInteger = intArg;
-			ArgKind = CppTemplateArgumentKind.AsInteger;
-		}
+            ArgKind = CppTemplateArgumentKind.AsInteger;
+        }
 
-		public CppTemplateArgument(CppType sourceParam, string unknownStr)
+		public CppTemplateArgument(CppType sourceParam, string unknownStr) : base(CppTypeKind.TemplateArgumentType)
         {
 			SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
             ArgAsUnknown = unknownStr;
-			ArgKind = CppTemplateArgumentKind.Unknown;
-		}
+            ArgKind = CppTemplateArgumentKind.Unknown;
+        }
 
-		public CppTemplateArgumentKind ArgKind { get; }
+        public CppTemplateArgumentKind ArgKind { get; }
 
         public CppType ArgAsType { get; }
 
@@ -45,17 +45,17 @@ namespace CppAst
         {
             get
             {
-                switch(ArgKind)
+                switch (ArgKind)
                 {
                     case CppTemplateArgumentKind.AsType:
-                        return ArgAsType.ToString();
+                        return ArgAsType.FullName;
                     case CppTemplateArgumentKind.AsInteger:
                         return ArgAsInteger.ToString();
-					case CppTemplateArgumentKind.Unknown:
+                    case CppTemplateArgumentKind.Unknown:
                         return ArgAsUnknown;
                     default:
                         return "?";
-				}
+                }
             }
         }
 
@@ -65,6 +65,20 @@ namespace CppAst
         /// </summary>
         public CppType SourceParam { get; }
 
+
+        /// <inheritdoc />
+        public override int SizeOf
+        {
+            get => 0;
+            set => throw new InvalidOperationException("This type does not support SizeOf");
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            return ReferenceEquals(this, obj) || obj is CppTemplateArgument other && Equals(other);
+        }
+
         /// <inheritdoc />
         public override int GetHashCode()
         {
@@ -73,6 +87,12 @@ namespace CppAst
                 return (base.GetHashCode() * 397) ^ SourceParam.GetHashCode() ^ ArgString.GetHashCode();
             }
         }
+
+
+        /// <inheritdoc />
+        public override CppType GetCanonicalType() => this;
+
+        /// <inheritdoc />
 
 
         /// <inheritdoc />

--- a/src/CppAst/CppType.cs
+++ b/src/CppAst/CppType.cs
@@ -48,5 +48,16 @@ namespace CppAst
         /// </summary>
         /// <returns>A canonical type of this type instance</returns>
         public abstract CppType GetCanonicalType();
+
+        /// <summary>
+        /// We can use this name in exporter to use this type.
+        /// </summary>
+        public virtual string FullName
+        {
+            get
+            {
+                return ToString();
+            }
+        }
     }
 }

--- a/src/CppAst/CppTypeKind.cs
+++ b/src/CppAst/CppTypeKind.cs
@@ -54,6 +54,10 @@ namespace CppAst
 		/// </summary>
 		TemplateParameterNonType,
 		/// <summary>
+		/// A template specialized argument type.
+		/// </summary>
+		TemplateArgumentType,
+		/// <summary>
 		/// An unexposed type.
 		/// </summary>
 		Unexposed,

--- a/src/CppAst/CppTypedef.cs
+++ b/src/CppAst/CppTypedef.cs
@@ -34,23 +34,23 @@ namespace CppAst
         /// </summary>
         public string Name { get; set; }
 
-		public string FullName
-		{
-			get
-			{
-				string fullparent = FullParentName;
-				if (string.IsNullOrEmpty(fullparent))
-				{
-					return Name;
-				}
-				else
-				{
-					return $"{fullparent}{Name}";
-				}
-			}
-		}
+        public override string FullName
+        {
+            get
+            {
+                string fullparent = FullParentName;
+                if (string.IsNullOrEmpty(fullparent))
+                {
+                    return Name;
+                }
+                else
+                {
+                    return $"{fullparent}::{Name}";
+                }
+            }
+        }
 
-		private bool Equals(CppTypedef other)
+        private bool Equals(CppTypedef other)
         {
             return base.Equals(other) && string.Equals(Name, other.Name);
         }


### PR DESCRIPTION
1. add support for function template
2. add inline namespace support
3. change FullName as a CppType property, and deduce the CppClass full name with specialized template right, you can just use CppClass full name in a generated c++ codes now.
4. FindByFullName() now can search auto ignore inline namespace now(such as clang std::__1::vector, now you can just use std::vector to search)
5. fix crash when the CppClass has a  specialized template with PartialSpecializedTemplateDecl
6. fix crash when typedef with a AliasTemplateDecl for Underlying type.