### PR TITLE
Update ClangSharp to 16.0.0

### DIFF
--- a/src/CppAst.Tests/InlineTestBase.cs
+++ b/src/CppAst.Tests/InlineTestBase.cs
@@ -10,7 +10,7 @@ namespace CppAst.Tests
         {
             if (assertCompilation == null) throw new ArgumentNullException(nameof(assertCompilation));
 
-            options = options ?? new CppParserOptions();
+            options ??= new CppParserOptions();
             var currentDirectory = Environment.CurrentDirectory;
             var headerFilename = $"{TestContext.CurrentContext.Test.FullName}-{TestContext.CurrentContext.Test.ID}.h";
             var headerFile = Path.Combine(currentDirectory, headerFilename);

--- a/src/CppAst.Tests/TestTypeAliases.cs
+++ b/src/CppAst.Tests/TestTypeAliases.cs
@@ -102,7 +102,7 @@ using MyStruct = struct {
 
                     Assert.AreEqual(1, compilation.Classes.Count);
                     Assert.AreEqual(1, compilation.Typedefs.Count);
-                    Assert.AreEqual("", compilation.Classes[0].Name);
+                    Assert.AreEqual("MyStruct", compilation.Classes[0].Name);
                     Assert.AreEqual("MyStruct", compilation.Typedefs[0].Name);
                 },
                 new CppParserOptions() { AutoSquashTypedef = false }

--- a/src/CppAst.Tests/TestTypedefs.cs
+++ b/src/CppAst.Tests/TestTypedefs.cs
@@ -102,7 +102,7 @@ typedef struct {
 
                     Assert.AreEqual(1, compilation.Classes.Count);
                     Assert.AreEqual(1, compilation.Typedefs.Count);
-                    Assert.AreEqual("", compilation.Classes[0].Name);
+                    Assert.AreEqual("MyStruct", compilation.Classes[0].Name);
                     Assert.AreEqual("MyStruct", compilation.Typedefs[0].Name);
                 },
                 new CppParserOptions() { AutoSquashTypedef = false }

--- a/src/CppAst/CppAst.csproj
+++ b/src/CppAst/CppAst.csproj
@@ -27,11 +27,11 @@
     <None Include="../../img/cppast.png" Pack="true" PackagePath="/logo.png" />
     <None Include="../../readme.md" Pack="true" PackagePath="/" />
 
-    <PackageReference Include="ClangSharp" Version="15.0.2" />
+    <PackageReference Include="ClangSharp" Version="16.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="4.2.0">
+    <PackageReference Include="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Update ClangSharp to 16.0.0, some tests failes due to how squash types are handled. any thoughts?