### PR TITLE
Move Qualifier at the end in CppQualifiedType

### DIFF
--- a/src/CppAst.Tests/TestTypes.cs
+++ b/src/CppAst.Tests/TestTypes.cs
@@ -212,6 +212,7 @@ class TmpClass;
 namespace ns2 {
 const ns1::TmpClass* tmpClass1;
 volatile ns1::TmpClass* tmpClass2;
+const unsigned int * const dummy_pu32 = (const unsigned int * const)0x12345678;
 }
 
 namespace ns1 {
@@ -225,11 +226,14 @@ class TmpClass {
 
                     var tmpClass1 = compilation.Namespaces[1].Fields[0];
                     var tmpClass2 = compilation.Namespaces[1].Fields[1];
+                    var constDummyPointer = compilation.Namespaces[1].Fields[2];
 
                     var hoge = tmpClass1.Type.GetDisplayName();
                     var hoge2 = tmpClass2.Type.GetDisplayName();
-                    Assert.AreEqual("const TmpClass*", tmpClass1.Type.GetDisplayName());
-                    Assert.AreEqual("volatile TmpClass*", tmpClass2.Type.GetDisplayName());
+                    var hoge3 = tmpClass2.Type.GetDisplayName();
+                    Assert.AreEqual("TmpClass const *", tmpClass1.Type.GetDisplayName());
+                    Assert.AreEqual("TmpClass volatile *", tmpClass2.Type.GetDisplayName());
+                    Assert.AreEqual("unsigned int const * const", constDummyPointer.Type.GetDisplayName());
                 }
             );
         }

--- a/src/CppAst/CppPointerType.cs
+++ b/src/CppAst/CppPointerType.cs
@@ -23,7 +23,7 @@ namespace CppAst
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{ElementType.GetDisplayName()}*";
+            return $"{ElementType.GetDisplayName()} *";
         }
 
         /// <inheritdoc />

--- a/src/CppAst/CppQualifiedType.cs
+++ b/src/CppAst/CppQualifiedType.cs
@@ -55,7 +55,7 @@ namespace CppAst
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{Qualifier.ToString().ToLowerInvariant()} {ElementType.GetDisplayName()}";
+            return $"{ElementType.GetDisplayName()} {Qualifier.ToString().ToLowerInvariant()}";
         }
     }
 }


### PR DESCRIPTION
Move the qualifier to the end of it's ToString Method.
To increase the readability due to this change also a space is inserted between the ElementType's Name and the Pointer-Character (*) in the CppPointerType.

This will solve the problem mentioned in #70 .

Examples for the Input and Output **before** the change:
const int * const   => const const int* (syntactically incorrect)
int const * const   => const const int* (syntactically incorrect)
const int *            => const int*           (syntactically correct)
const int              => const int             (syntactically correct)

Examples for the Input and Output **after** the change:
const int * const   => int const * const (syntactically correct)
int const * const   => int const * const (syntactically correct)
const int *            => int const *           (syntactically correct)
const int               => int const             (syntactically correct)

This change would follow the Spiral-Rule [https://c-faq.com/decl/spiral.anderson.html](url).
Perhaps it's uncommon to have an `int const` instead of a `const int`. But it is syntactically correct.

Currently the parent of the types is not filled so you simply can't perform a lookup if the previous one was a CppPointerType.