### PR TITLE
fix "Unhandled PrimitiveKind: Long" in CppPrimitiveType.ToString()

### DIFF
--- a/src/CppAst/CppPrimitiveType.cs
+++ b/src/CppAst/CppPrimitiveType.cs
@@ -178,6 +178,10 @@ namespace CppAst
                     return "short";
                 case CppPrimitiveKind.Int:
                     return "int";
+                case CppPrimitiveKind.Long:
+                    return "long";
+                case CppPrimitiveKind.UnsignedLong:
+                    return "unsigned long";
                 case CppPrimitiveKind.LongLong:
                     return "long long";
                 case CppPrimitiveKind.UnsignedChar:


### PR DESCRIPTION
 type "long" and "unsigned long" are missed in ToString()