### PR TITLE
fix: skip conditions checking on source span assignment

### DIFF
--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -434,11 +434,8 @@ namespace CppAst
 
             if (element != null)
             {
-                bool isForwardDeclaration = (element is CppClass || element is CppEnum) && !cursor.IsDefinition;
-                if (!isForwardDeclaration) {
-                    AssignSourceSpan(cursor, element);
-                }
-            }
+				AssignSourceSpan(cursor, element);
+			}
 
             if (element is ICppDeclaration cppDeclaration)
             {
@@ -829,9 +826,8 @@ namespace CppAst
         {
             var start = cursor.Extent.Start;
             var end = cursor.Extent.End;
-            if (element.Span.Start.File is null)
-                element.Span = new CppSourceSpan(GetSourceLocation(start), GetSourceLocation(end));
-        }
+			element.Span = new CppSourceSpan(GetSourceLocation(start), GetSourceLocation(end));
+		}
 
         public static CppSourceLocation GetSourceLocation(CXSourceLocation start)
         {

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -435,7 +435,7 @@ namespace CppAst
             if (element != null)
             {
                 AssignSourceSpan(cursor, element);
-			}
+            }
 
             if (element is ICppDeclaration cppDeclaration)
             {
@@ -828,7 +828,7 @@ namespace CppAst
             var end = cursor.Extent.End;
 
             element.Span = new CppSourceSpan(GetSourceLocation(start), GetSourceLocation(end));
-		}
+        }
 
         public static CppSourceLocation GetSourceLocation(CXSourceLocation start)
         {

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -434,7 +434,7 @@ namespace CppAst
 
             if (element != null)
             {
-				AssignSourceSpan(cursor, element);
+                AssignSourceSpan(cursor, element);
 			}
 
             if (element is ICppDeclaration cppDeclaration)
@@ -826,7 +826,8 @@ namespace CppAst
         {
             var start = cursor.Extent.Start;
             var end = cursor.Extent.End;
-			element.Span = new CppSourceSpan(GetSourceLocation(start), GetSourceLocation(end));
+
+            element.Span = new CppSourceSpan(GetSourceLocation(start), GetSourceLocation(end));
 		}
 
         public static CppSourceLocation GetSourceLocation(CXSourceLocation start)


### PR DESCRIPTION
For some reason after updating to latest version my parser stopped working properly. I found out that these two conditions checking were problematic introduced in [488679f](https://github.com/xoofx/CppAst.NET/commit/488679fcd3d75f6704dff9fe2f1cb5d8a8553797). I guess it is messing up the source file which I'm depending on.