### PR TITLE
Fix FullParentName for types not in a root namespace

### DIFF
--- a/src/CppAst/CppElement.cs
+++ b/src/CppAst/CppElement.cs
@@ -56,6 +56,11 @@ namespace CppAst
                         // root namespace here, just ignore~
                         p = null;
                     }
+                    else if (p is CppGlobalDeclarationContainer)
+                    {
+                       // root container here, just ignore~
+                       p = null;
+                    }
                     else
                     {
                         throw new NotImplementedException("Can not be here, not support type here!");


### PR DESCRIPTION
This was an issue I ran into while making a code generator.  I didn't end up depending on this codepath, but thought it might still be useful to you or other users of the library.  Unfortunately, I cannot remember how to repro the issue I was seeing.