### PR TITLE
Fix: Replace wchar with wchar_t for standardization and compatibility

### DIFF
--- a/src/CppAst.Tests/TestTypeAliases.cs
+++ b/src/CppAst.Tests/TestTypeAliases.cs
@@ -12,7 +12,7 @@ using Type_void = void;
 
 using Type_bool = bool;
 
-using Type_wchar = wchar_t ;
+using Type_wchar_t = wchar_t ;
 
 using Type_char = char;
 using Type_unsigned_char = unsigned char;

--- a/src/CppAst.Tests/TestTypedefs.cs
+++ b/src/CppAst.Tests/TestTypedefs.cs
@@ -12,7 +12,7 @@ typedef void Type_void;
 
 typedef bool Type_bool;
 
-typedef wchar_t Type_wchar;
+typedef wchar_t Type_wchar_t;
 
 typedef char Type_char;
 typedef unsigned char Type_unsigned_char;

--- a/src/CppAst/CppPrimitiveType.cs
+++ b/src/CppAst/CppPrimitiveType.cs
@@ -171,7 +171,7 @@ namespace CppAst
                 case CppPrimitiveKind.Void:
                     return "void";
                 case CppPrimitiveKind.WChar:
-                    return "wchar";
+                    return "wchar_t";
                 case CppPrimitiveKind.Char:
                     return "char";
                 case CppPrimitiveKind.Short:


### PR DESCRIPTION
### Summary
This pull request replaces occurrences of `wchar` with `wchar_t` to ensure code standardization and improve compatibility across platforms.

### Details
- **Issue**: `wchar` is not a standard keyword and may cause compatibility issues.
- **Fix**: Replaced `wchar` with the standardized `wchar_t`.

### References
For more details on `wchar_t`, see the [cppreference documentation](https://en.cppreference.com/w/cpp/keyword/wchar_t).