### PR TITLE
CMake C# lang version bump and template specialized arguments exception fix

### DIFF
--- a/src/CppAst/CMakeLists.txt
+++ b/src/CppAst/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB_RECURSE SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.cs)
 
-set(CMAKE_CSharp_FLAGS "${CMAKE_CSharp_FLAGS} /langversion:7.3")
+set(CMAKE_CSharp_FLAGS "${CMAKE_CSharp_FLAGS} /langversion:10")
 
 add_library(CppAst SHARED ${SOURCE_FILES})
 

--- a/src/CppAst/CMakeLists.txt
+++ b/src/CppAst/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CSharp_FLAGS "${CMAKE_CSharp_FLAGS} /langversion:10")
 add_library(CppAst SHARED ${SOURCE_FILES})
 
 set_target_properties(CppAst PROPERTIES
-    VS_PACKAGE_REFERENCES "ClangSharp_17.0.1;Irony_1.2.0"
+    VS_PACKAGE_REFERENCES "ClangSharp_20.1.2;Irony_1.2.0"
 )
 
 target_compile_options(CppAst PUBLIC "/unsafe")

--- a/src/CppAst/CppContainerList.cs
+++ b/src/CppAst/CppContainerList.cs
@@ -58,7 +58,17 @@ namespace CppAst
             {
                 foreach (var element in collection)
                 {
-                    Add(element);
+                    // Check if given element is already resolved
+                    if (element.Parent == null)
+                    {
+                        // If not, create one
+                        Add(element);
+                    }
+                    else
+                    {
+                        // Otherwise, just reference it
+                        _elements.Add(element);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR bumps C# version to 10 inside CMake file and fixes an exception raised at https://github.com/xoofx/CppAst.NET/blob/86ef17c41de9ebfd218e153feade6965ee1c9781/src/CppAst/CppModelBuilder.cs#L2361
Looks like 'ParseTemplateSpecializedArguments' gives us already resolved types (by resolved I mean with set Parent) and since 'AddRange' is called only once here, I have solved this issue by checking if Parent is already set, if so, just reference the item without setting new Parent.